### PR TITLE
Fixing typo laempy

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Conda installation is recommended. To install *Pyoints* with
 [Conda](https://conda.io/docs/user-guide/getting-started.html) run:
 
 ```
-conda install -c leampy pyoints
+conda install -c laempy pyoints
 ```
 
 Currently Linux (64 bit) and Windows (64 bit) have been packaged.


### PR DESCRIPTION
Received this error during installation:

`conda install -c leampy pyoints`
Solving environment: failed

CondaHTTPError: HTTP 404 NOT FOUND for url <https://conda.anaconda.org/leampy/noarch/repodata.json>
Elapsed: 00:00.131283
CF-RAY: 4855b61df9872d3b-TXL

The remote server could not find the noarch directory for the
requested channel with url: https://conda.anaconda.org/leampy
